### PR TITLE
chore: trigger release-notes-docs-pr after release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,3 +150,17 @@ jobs:
               ref: 'master'
             });
             console.log('✅ Triggered use-shared-publish workflow')
+
+      - name: Trigger Release Notes Docs PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const version = '${{ needs.release.outputs.new-release-version }}';
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'release-notes-docs-pr.yml',
+              ref: 'master',
+              inputs: { tag: `v${version}`, dry_run: 'false' }
+            });
+            console.log(`✅ Triggered release-notes-docs-pr.yml for v${version}`)


### PR DESCRIPTION
## Summary

GitHub Actions does not fire downstream workflow triggers (like `release: published`) for events created by `GITHUB_TOKEN`. This means `release-notes-docs-pr.yml` never auto-fires after an automated release.

**Fix:** Explicitly dispatch `release-notes-docs-pr.yml` via `actions/github-script` after semantic-release creates the GitHub release in `release.yml`.

## Test plan

- [ ] Merge and trigger a release — verify `release-notes-docs-pr.yml` runs automatically
- [ ] Alternatively, run `release.yml` via workflow_dispatch and confirm the docs PR workflow is triggered