### PR TITLE
chore: align release notes and changelog format with docs template

### DIFF
--- a/.github/workflows/release-notes-docs-pr.yml
+++ b/.github/workflows/release-notes-docs-pr.yml
@@ -92,7 +92,11 @@ jobs:
           tag="${{ steps.release.outputs.tag }}"
           version="${tag#v}"
           releaseDate="${{ steps.release.outputs.releaseDate }}"
-          fileDate=$(date -u "+%y-%m-%d")
+          if [[ -n "${releaseDate}" ]]; then
+            fileDate="${releaseDate:2}"
+          else
+            fileDate=$(date -u "+%y-%m-%d")
+          fi
           releaseFile="${{ env.DOCS_FOLDER }}/${{ env.AGENT_FILE_PREFIX }}-${fileDate}.mdx"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "releaseFile=${releaseFile}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-notes-docs-pr.yml
+++ b/.github/workflows/release-notes-docs-pr.yml
@@ -31,6 +31,9 @@ jobs:
     name: Update public docs
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v1
@@ -42,20 +45,24 @@ jobs:
 
       - name: Resolve release tag and body
         id: release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             tag="${{ github.event.inputs.tag }}"
           else
             tag="${{ github.event.release.tag_name }}"
           fi
-          body=$(gh release view "${tag}" --repo ${{ env.AGENT_REPO }} --json body --jq '.body')
           version="${tag#v}"
-          releaseDate=$(gh api "repos/${{ env.AGENT_REPO }}/contents/CHANGELOG.md" --jq '.content' | \
-            base64 -d | \
-            grep -m1 "^## \[${version}\]" | \
+          releaseDate=$(grep -m1 "^## \[${version}\]" CHANGELOG.md | \
             grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}')
+          body=$(awk -v ver="${version}" '
+            found && /^## +\[|^# / { exit }
+            found { print }
+            $0 ~ ("^## +\\[" ver "\\]") { found=1 }
+          ' CHANGELOG.md | sed -E 's/ *\(\[[0-9a-f]{6,40}\]\([^)]*\)\) *$//')
+          body=$(printf '%s' "${body}" | sed '/[^[:space:]]/,$!d' | sed -e :a -e '/^[[:space:]]*$/{$d;N;ba}')
+          if [[ -z "${body}" ]]; then
+            body="_No new features, improvements, or bug fixes for this release._"
+          fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "releaseDate=${releaseDate}" >> "$GITHUB_OUTPUT"
           echo "body<<RELEASE_BODY_EOF" >> "$GITHUB_OUTPUT"
@@ -97,11 +104,6 @@ jobs:
         env:
           RELEASE_BODY: ${{ steps.release.outputs.body }}
         run: |
-          processed=$(printf '%s\n' "${RELEASE_BODY}" | \
-            tr -d '\r' | \
-            awk 'BEGIN{s=1} /^## /{s=0} !s{print}' | \
-            sed "s/## What's Changed/## What's changed/g; s/## Full Changelog/## Full changelog/g" | \
-            awk '/^## Full changelog/{fc=1;next} fc && /^https?:\/\//{printf "[Full changelog](%s)\n\n",$0;fc=0;next} fc && NF==0{next} {fc=0;print}')
           echo "=== DRY RUN: MDX file that would be created ==="
           echo "File: ${{ steps.mdx.outputs.releaseFile }}"
           echo ""
@@ -114,7 +116,7 @@ jobs:
           printf '%s\n' 'category: ${{ env.AGENT_NAME }}'
           printf '%s\n' '---'
           printf '\n'
-          printf '%s\n' "${processed}"
+          printf '%s\n' "${RELEASE_BODY}"
 
       - name: Write release notes and open PR
         if: ${{ github.event.inputs.dry_run != 'true' }}
@@ -135,12 +137,6 @@ jobs:
             exit 0
           fi
 
-          processed=$(printf '%s\n' "${RELEASE_BODY}" | \
-            tr -d '\r' | \
-            awk 'BEGIN{s=1} /^## /{s=0} !s{print}' | \
-            sed "s/## What's Changed/## What's changed/g; s/## Full Changelog/## Full changelog/g" | \
-            awk '/^## Full changelog/{fc=1;next} fc && /^https?:\/\//{printf "[Full changelog](%s)\n\n",$0;fc=0;next} fc && NF==0{next} {fc=0;print}')
-
           {
             printf '%s\n' '---'
             printf '%s\n' 'subject: ${{ env.AGENT_SUBJECT }}'
@@ -151,7 +147,7 @@ jobs:
             printf '%s\n' 'category: ${{ env.AGENT_NAME }}'
             printf '%s\n' '---'
             printf '\n'
-            printf '%s\n' "${processed}"
+            printf '%s\n' "${RELEASE_BODY}"
           } > "${releaseFile}"
 
           git checkout -b "${branchName}"

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -23,13 +23,13 @@
     [
       "@semantic-release/release-notes-generator",
       {
-        "preset": "angular",
+        "preset": "conventionalcommits",
         "presetConfig": {
           "types": [
-            {"type": "feat", "section": "Features"},
-            {"type": "fix", "section": "Bug Fixes"},
-            {"type": "perf", "section": "Performance Improvements"},
-            {"type": "revert", "section": "Reverts"},
+            {"type": "feat", "section": "New features"},
+            {"type": "fix", "section": "Bug fixes"},
+            {"type": "perf", "section": "Improvements"},
+            {"type": "revert", "section": "Reverts", "hidden": true},
             {"type": "docs", "section": "Documentation", "hidden": true},
             {"type": "style", "section": "Styles", "hidden": true},
             {"type": "chore", "section": "Chores", "hidden": true},

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@semantic-release/npm": "^12.0.0",
         "@semantic-release/release-notes-generator": "^13.0.0",
         "babel-loader": "^8.0.0",
+        "conventional-changelog-conventionalcommits": "^7.0.2",
         "semantic-release": "^23.0.8",
         "webpack": "5.99.9",
         "webpack-cli": "5.1.4"
@@ -6163,6 +6164,19 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
       "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@semantic-release/npm": "^12.0.0",
     "@semantic-release/release-notes-generator": "^13.0.0",
     "babel-loader": "^8.0.0",
+    "conventional-changelog-conventionalcommits": "^7.0.2",
     "semantic-release": "^23.0.8",
     "webpack": "5.99.9",
     "webpack-cli": "5.1.4"


### PR DESCRIPTION
## Summary
- Switches `.releaserc.json` to the conventionalcommits preset with section names matching the docs agent-release-notes template (`New features` / `Bug fixes` / `Improvements`). Since this repo runs `npx semantic-release` directly (via `@semantic-release/github`), this also fixes the GitHub Release body — no separate `--generate-notes` step to change here.
- `release-notes-docs-pr.yml`: extracts a version's notes directly from `CHANGELOG.md` (stripping commit-hash links) instead of `gh release view`/`gh api` calls, with a fallback message when a version isn't found.

Same fix as newrelic/video-html5-js#69, applied here since this repo shares a similar release pipeline (though notes flow through `@semantic-release/github` directly rather than a separate `gh release create` step).

Not in scope for this PR (flagged separately): `CHANGELOG.md` has no entry for the current `v4.0.0` release — pre-existing gap, not touched here since it needs its own investigation into the underlying breaking-change commits.

## Test plan
- [ ] Verify `.releaserc.json` produces correctly-sectioned changelog entries on the next release
- [ ] Run `release-notes-docs-pr.yml` with `dry_run: true` and confirm it falls back gracefully given the current CHANGELOG.md gap