### PR TITLE
docs: add harvest cycle configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,19 @@ Configure how frequently data is sent to New Relic. Accepts values between 1000m
 tracker.setHarvestInterval(30000); // Send data every 30 seconds
 ```
 
+### Live Stream Configuration
+
+**Recommendations for Live Content:**
+
+For live streams, reduce the harvest interval to 5,000–10,000 ms for near-real-time data delivery:
+
+```javascript
+// Live content — flush every 5 seconds
+tracker.setHarvestInterval(5000)
+
+// VOD content — default 10s is sufficient or change it as required
+```
+
 #### `tracker.sendCustom(actionName, state, attributes)`
 
 Send a custom event with arbitrary attributes.


### PR DESCRIPTION
Adds `### Live Stream Configuration` section to README.md.

Part of [PRD: Harvest Cycle Configuration Documentation](https://newrelic.atlassian.net/wiki/spaces/VERTSOL/pages/5952111079/PRD+Harvest+Cycle+Configuration+Documentation).